### PR TITLE
feat: add Redis Cache

### DIFF
--- a/src/main/java/kr/bos/BosApplication.java
+++ b/src/main/java/kr/bos/BosApplication.java
@@ -2,11 +2,13 @@ package kr.bos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 /**
  * Starting point of an application.
 */
+@EnableCaching
 @EnableRedisHttpSession
 @SpringBootApplication
 public class BosApplication {

--- a/src/main/java/kr/bos/config/RedisConfig.java
+++ b/src/main/java/kr/bos/config/RedisConfig.java
@@ -1,0 +1,114 @@
+package kr.bos.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * RedisConfig. 레디스의 세션과 캐시 사용을 분리하기 위한 설정.
+ *
+ * @since 1.0.0
+ */
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.session.host}")
+    private String redisSessionHost;
+
+    @Value("${spring.redis.session.port}")
+    private int redisSessionPort;
+
+    @Value("${spring.redis.session.password}")
+    private String redisSessionPassword;
+
+    @Value("${spring.redis.cache.host}")
+    private String redisCacheHost;
+
+    @Value("${spring.redis.cache.port}")
+    private int redisCachePort;
+
+    @Value("${spring.redis.cache.password}")
+    private String redisCachePassword;
+
+    /**
+     * Session 사용을 위한 RedisConnectionFactory Bean 등록.
+     * <br>
+     * RedisConnectionFactory: 레디스 서버 연결을 위한 Connection을 관리하는 인터페이스.
+     *
+     * @since 1.0.0
+     */
+    @Bean({"redisConnectionFactory", "redisSessionConnectionFactory"})
+    public RedisConnectionFactory redisSessionConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfig = new RedisStandaloneConfiguration();
+        redisStandaloneConfig.setHostName(redisSessionHost);
+        redisStandaloneConfig.setPort(redisSessionPort);
+        redisStandaloneConfig.setPassword(redisCachePassword);
+        return new LettuceConnectionFactory(redisStandaloneConfig);
+    }
+
+    /**
+     * Cache 사용을 위한 RedisConnectionFactory Bean 등록.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public RedisConnectionFactory redisCacheConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfig = new RedisStandaloneConfiguration();
+        redisStandaloneConfig.setHostName(redisCacheHost);
+        redisStandaloneConfig.setPort(redisCachePort);
+        redisStandaloneConfig.setPassword(redisCachePassword);
+        return new LettuceConnectionFactory(redisStandaloneConfig);
+    }
+
+    /**
+     * Redis Template Bean 등록.
+     * <br>
+     * RedisTemplate: Session RedisConnection 에서 넘겨준 byte 를 직렬화하는 역할 수행.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisSessionConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    /**
+     * RedisCacheManager Bean 등록.
+     * <br>
+     * RedisCacheManager: 스프링에서 추상화되어있는 CacheManager 인터페이스를 레디스 사용을 위해 구현한 클래스.
+     * 캐시 key, value를 직렬화, 역직렬화 하기위한 설정 입력.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public RedisCacheManager redisCacheManager(
+        @Qualifier("redisCacheConnectionFactory") RedisConnectionFactory redisConnectionFactory,
+        ObjectMapper objectMapper) {
+        RedisCacheConfiguration redisCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues().entryTtl(Duration.ofMinutes(20L)).serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer())).serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer(objectMapper)));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfig).build();
+    }
+}

--- a/src/main/java/kr/bos/controller/StudyCafeController.java
+++ b/src/main/java/kr/bos/controller/StudyCafeController.java
@@ -173,7 +173,7 @@ public class StudyCafeController {
     public void updateReview(@CurrentUserId Long userId,
         @PathVariable("studyCafeId") Long studyCafeId, @PathVariable("reviewId") Long reviewId,
         @RequestBody ReviewReq reviewReq) {
-        reviewService.updateReview(reviewReq, userId, studyCafeId, reviewId);
+        reviewService.updateReview(reviewReq, userId, reviewId);
     }
 
     /**
@@ -187,7 +187,7 @@ public class StudyCafeController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteReview(@CurrentUserId Long userId,
         @PathVariable("studyCafeId") Long studyCafeId, @PathVariable("reviewId") Long reviewId) {
-        reviewService.deleteReview(userId, studyCafeId, reviewId);
+        reviewService.deleteReview(userId, reviewId);
     }
 
     /**

--- a/src/main/java/kr/bos/controller/StudyCafeController.java
+++ b/src/main/java/kr/bos/controller/StudyCafeController.java
@@ -170,9 +170,10 @@ public class StudyCafeController {
     @LoginCheck
     @BlackCheck
     @ResponseStatus(HttpStatus.OK)
-    public void updateReview(@CurrentUserId Long userId, @PathVariable("reviewId") Long reviewId,
+    public void updateReview(@CurrentUserId Long userId,
+        @PathVariable("studyCafeId") Long studyCafeId, @PathVariable("reviewId") Long reviewId,
         @RequestBody ReviewReq reviewReq) {
-        reviewService.updateReview(reviewReq, userId, reviewId);
+        reviewService.updateReview(reviewReq, userId, studyCafeId, reviewId);
     }
 
     /**
@@ -186,7 +187,7 @@ public class StudyCafeController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteReview(@CurrentUserId Long userId,
         @PathVariable("studyCafeId") Long studyCafeId, @PathVariable("reviewId") Long reviewId) {
-        reviewService.deleteReview(userId, reviewId);
+        reviewService.deleteReview(userId, studyCafeId, reviewId);
     }
 
     /**

--- a/src/main/java/kr/bos/service/ReviewService.java
+++ b/src/main/java/kr/bos/service/ReviewService.java
@@ -43,7 +43,6 @@ public class ReviewService {
      *
      * @since 1.0.0
      */
-    @CacheEvict(value = "reviews", key = "#studyCafeId")
     public void createReview(ReviewReq reviewReq, Long userId, Long studyCafeId) {
         Review review = Review.builder()
             .userId(userId)
@@ -60,13 +59,11 @@ public class ReviewService {
      *
      * @param reviewReq 리뷰 Request DTO
      * @param userId 유저 ID
-     * @param studyCafeId 스터디카페 ID - 캐싱을 위한 파라미터.
      * @param reviewId 리뷰 ID
      *
      * @since 1.0.0
      */
-    @CacheEvict(value = "reviews", key = "#studyCafeId")
-    public void updateReview(ReviewReq reviewReq, Long userId, Long studyCafeId, Long reviewId) {
+    public void updateReview(ReviewReq reviewReq, Long userId, Long reviewId) {
         Review review = Review.builder()
             .id(reviewId)
             .userId(userId)
@@ -84,13 +81,11 @@ public class ReviewService {
      * 리뷰 삭제하기. 삭제 실패시 ReviewNotFoundException 예외 발생.
      *
      * @param userId 유저 ID
-     * @param studyCafeId 스터디카페 ID - 캐싱을 위한 파라미터.
      * @param reviewId 리뷰 ID
      *
      * @since 1.0.0
      */
-    @CacheEvict(value = "reviews", key = "#studyCafeId")
-    public void deleteReview(Long userId, Long studyCafeId, Long reviewId) {
+    public void deleteReview(Long userId, Long reviewId) {
         int deleteCount = reviewMapper.deleteReview(userId, reviewId);
         if (deleteCount == 0) {
             throw new ReviewNotFoundException();

--- a/src/main/java/kr/bos/service/ReviewService.java
+++ b/src/main/java/kr/bos/service/ReviewService.java
@@ -1,13 +1,14 @@
 package kr.bos.service;
 
 import java.util.List;
-import kr.bos.exception.AccessDeniedException;
 import kr.bos.exception.ReviewNotFoundException;
 import kr.bos.mapper.ReviewMapper;
 import kr.bos.model.domain.Review;
 import kr.bos.model.dto.request.ReviewReq;
 import kr.bos.model.dto.response.ReviewRes;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -24,8 +25,11 @@ public class ReviewService {
     /**
      * 리뷰 목록 조회하기.
      *
+     * @param studyCafeId 스터디카페 ID
+*
      * @since 1.0.0
      */
+    @Cacheable(value = "reviews", key = "#studyCafeId")
     public List<ReviewRes> getReviews(Long studyCafeId) {
         return reviewMapper.selectReviewsByStudyCafeId(studyCafeId);
     }
@@ -33,8 +37,13 @@ public class ReviewService {
     /**
      * 리뷰 생성하기.
      *
+     * @param reviewReq 리뷰 Request DTO
+     * @param userId 유저 ID
+     * @param studyCafeId 스터디카페 ID
+     *
      * @since 1.0.0
      */
+    @CacheEvict(value = "reviews", key = "#studyCafeId")
     public void createReview(ReviewReq reviewReq, Long userId, Long studyCafeId) {
         Review review = Review.builder()
             .userId(userId)
@@ -49,9 +58,15 @@ public class ReviewService {
     /**
      * 리뷰 업데이트. 업데이트 실패시 ReviewNotFoundException 예외 발생.
      *
+     * @param reviewReq 리뷰 Request DTO
+     * @param userId 유저 ID
+     * @param studyCafeId 스터디카페 ID - 캐싱을 위한 파라미터.
+     * @param reviewId 리뷰 ID
+     *
      * @since 1.0.0
      */
-    public void updateReview(ReviewReq reviewReq, Long userId, Long reviewId) {
+    @CacheEvict(value = "reviews", key = "#studyCafeId")
+    public void updateReview(ReviewReq reviewReq, Long userId, Long studyCafeId, Long reviewId) {
         Review review = Review.builder()
             .id(reviewId)
             .userId(userId)
@@ -68,9 +83,14 @@ public class ReviewService {
     /**
      * 리뷰 삭제하기. 삭제 실패시 ReviewNotFoundException 예외 발생.
      *
+     * @param userId 유저 ID
+     * @param studyCafeId 스터디카페 ID - 캐싱을 위한 파라미터.
+     * @param reviewId 리뷰 ID
+     *
      * @since 1.0.0
      */
-    public void deleteReview(Long userId, Long reviewId) {
+    @CacheEvict(value = "reviews", key = "#studyCafeId")
+    public void deleteReview(Long userId, Long studyCafeId, Long reviewId) {
         int deleteCount = reviewMapper.deleteReview(userId, reviewId);
         if (deleteCount == 0) {
             throw new ReviewNotFoundException();

--- a/src/test/java/kr/bos/service/ReviewServiceTest.java
+++ b/src/test/java/kr/bos/service/ReviewServiceTest.java
@@ -53,7 +53,7 @@ class ReviewServiceTest {
     @DisplayName("리뷰 업데이트에 성공합니다.")
     public void updateReviewWhenSuccess() {
         when(reviewMapper.updateReview(any(Review.class))).thenReturn(1);
-        reviewService.updateReview(reviewReq, 1L, 2L);
+        reviewService.updateReview(reviewReq, 1L, 2L, 3L);
         verify(reviewMapper).updateReview(any(Review.class));
     }
 
@@ -62,7 +62,7 @@ class ReviewServiceTest {
     public void updateReviewWhenFail() {
         when(reviewMapper.updateReview(any(Review.class))).thenReturn(0);
         assertThrows(ReviewNotFoundException.class,
-            () -> reviewService.updateReview(reviewReq, 1L, 2L));
+            () -> reviewService.updateReview(reviewReq, 1L, 2L, 3L));
         verify(reviewMapper).updateReview(any(Review.class));
     }
 
@@ -70,7 +70,7 @@ class ReviewServiceTest {
     @DisplayName("리뷰 삭제에 성공합니다.")
     public void deleteReviewWhenSuccess() {
         when(reviewMapper.deleteReview(1L, 2L)).thenReturn(1);
-        reviewService.deleteReview(1L, 2L);
+        reviewService.deleteReview(1L, 3L, 2L);
         verify(reviewMapper).deleteReview(1L, 2L);
     }
 
@@ -79,7 +79,7 @@ class ReviewServiceTest {
     public void deleteReviewWhenFail() {
         when(reviewMapper.deleteReview(1L, 2L)).thenReturn(0);
         assertThrows(ReviewNotFoundException.class,
-            () -> reviewService.deleteReview(1L, 2L));
+            () -> reviewService.deleteReview(1L, 3L, 2L));
         verify(reviewMapper).deleteReview(1L, 2L);
     }
 }

--- a/src/test/java/kr/bos/service/ReviewServiceTest.java
+++ b/src/test/java/kr/bos/service/ReviewServiceTest.java
@@ -53,7 +53,7 @@ class ReviewServiceTest {
     @DisplayName("리뷰 업데이트에 성공합니다.")
     public void updateReviewWhenSuccess() {
         when(reviewMapper.updateReview(any(Review.class))).thenReturn(1);
-        reviewService.updateReview(reviewReq, 1L, 2L, 3L);
+        reviewService.updateReview(reviewReq, 1L, 2L);
         verify(reviewMapper).updateReview(any(Review.class));
     }
 
@@ -62,7 +62,7 @@ class ReviewServiceTest {
     public void updateReviewWhenFail() {
         when(reviewMapper.updateReview(any(Review.class))).thenReturn(0);
         assertThrows(ReviewNotFoundException.class,
-            () -> reviewService.updateReview(reviewReq, 1L, 2L, 3L));
+            () -> reviewService.updateReview(reviewReq, 1L, 2L));
         verify(reviewMapper).updateReview(any(Review.class));
     }
 
@@ -70,7 +70,7 @@ class ReviewServiceTest {
     @DisplayName("리뷰 삭제에 성공합니다.")
     public void deleteReviewWhenSuccess() {
         when(reviewMapper.deleteReview(1L, 2L)).thenReturn(1);
-        reviewService.deleteReview(1L, 3L, 2L);
+        reviewService.deleteReview(1L, 2L);
         verify(reviewMapper).deleteReview(1L, 2L);
     }
 
@@ -79,7 +79,7 @@ class ReviewServiceTest {
     public void deleteReviewWhenFail() {
         when(reviewMapper.deleteReview(1L, 2L)).thenReturn(0);
         assertThrows(ReviewNotFoundException.class,
-            () -> reviewService.deleteReview(1L, 3L, 2L));
+            () -> reviewService.deleteReview(1L, 2L));
         verify(reviewMapper).deleteReview(1L, 2L);
     }
 }


### PR DESCRIPTION
Redis Cache 스토리지 사용.

RedisConfig 추가.
- Cache, Session 레디스 스토리지 분리.
- RedisCacheManager 등록

상품 상세페이지나, 목록 조회에 캐시를 사용하려했으나, 총 사용횟수, 현재 방의 상태 등의 정보도 포함되기 때문에 데이터가 쉽게 바뀌어 캐시를 사용하기에는 부적절하다고 생각했습니다. 일단 상대적으로 Write 작업이 많지 않을거라 생각되는 Review 조회 기능에 캐시를 적용했습니다. 리뷰 생성, 삭제, 업데이트시 캐시는 삭제됩니다.

---

리뷰 목록 조회는 캐시 적용했다가 다시 제외했습니다. 페이지네이션 처리를 위해 Pagehelper 라이브러리를 사용했는데, 이를 캐싱과 같이 사용하는 경우 문제가 발생할 수 있음을 확인했습니다. 그리고 레디스 key값에 페이징에 대한 값과, 이후 필터, 정렬 기능의 확장의 경우도 고려해 목록조회에 경우에는 캐싱을 적용하지않는 것이 좋다고 생각했습니다. 일단 Redis 설정만 미리해두고 이후 캐쉬 적용할 상황에 맞춰 사용하도록 하겠습니다.
