### PR TITLE
regist MySQL Replication

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -5,6 +5,7 @@ def jacocoExcludes = [
         '**/BosApplication.class',
         '**/GlobalExceptionHandler.class',
         '**/controller',
+        '**/DataSourceType.class',
 
         // Aspect
         '**/LoginCheckAspect.class',

--- a/src/main/java/kr/bos/config/DataSourceConfig.java
+++ b/src/main/java/kr/bos/config/DataSourceConfig.java
@@ -1,0 +1,118 @@
+package kr.bos.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import kr.bos.utils.DataSourceType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * DataSourceConfig. DB Replication 위한 설정.
+ *
+ * @since 1.0.0
+ */
+@Configuration
+@EnableTransactionManagement
+public class DataSourceConfig {
+
+    @Value("${spring.datasource.master.url}")
+    private String masterUrl;
+
+    @Value("${spring.datasource.master.username}")
+    private String masterUsername;
+
+    @Value("${spring.datasource.master.password}")
+    private String masterPassword;
+
+    @Value("${spring.datasource.slave.url}")
+    private String slaveUrl;
+
+    @Value("${spring.datasource.slave.username}")
+    private String slaveUsername;
+
+    @Value("${spring.datasource.slave.password}")
+    private String slavePassword;
+
+    /**
+     * MasterDataSource Bean 등록.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create()
+            .url(masterUrl)
+            .username(masterUsername)
+            .password(masterPassword)
+            .build();
+    }
+
+    /**
+     * SlaveDataSource Bean 등록.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create()
+            .url(slaveUrl)
+            .username(slaveUsername)
+            .password(slavePassword)
+            .build();
+    }
+
+    /**
+     * 트랜잭션의 readOnly 여부를 확인 후 Master, Slave Datasource 선택.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public DataSource routingDataSource(DataSource masterDataSource, DataSource slaveDataSource) {
+        AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+            @Override
+            protected Object determineCurrentLookupKey() {
+                return TransactionSynchronizationManager.isCurrentTransactionReadOnly()
+                    ? DataSourceType.SLAVE : DataSourceType.MASTER;
+            }
+        };
+
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put(DataSourceType.MASTER, masterDataSource);
+        targetDataSources.put(DataSourceType.SLAVE, slaveDataSource);
+
+        routingDataSource.setTargetDataSources(targetDataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+        return routingDataSource;
+    }
+
+    /**
+     * 쿼리가 발생하는 시점에 DataSource의 Connection을 가져오기 위한 트랜잭션의 LazyConnectionDataSourceProxy.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public DataSource proxyDataSource(DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    /**
+     * 트랜잭션 매니저에 LazyConnectionDataSourceProxy 등록.
+     *
+     * @since 1.0.0
+     */
+    @Bean
+    public PlatformTransactionManager transactionManager(DataSource proxyDataSource) {
+        DataSourceTransactionManager transactionManager = new DataSourceTransactionManager();
+        transactionManager.setDataSource(proxyDataSource);
+        return transactionManager;
+    }
+}

--- a/src/main/java/kr/bos/config/MyBatisConfig.java
+++ b/src/main/java/kr/bos/config/MyBatisConfig.java
@@ -29,9 +29,9 @@ public class MyBatisConfig {
      * @since 1.0.0
      */
     @Bean
-    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+    public SqlSessionFactory sqlSessionFactory(DataSource proxyDataSource) throws Exception {
         SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
-        sqlSessionFactoryBean.setDataSource(dataSource);
+        sqlSessionFactoryBean.setDataSource(proxyDataSource);
         sqlSessionFactoryBean
             .setMapperLocations(applicationContext.getResources("classpath:/mapper/**/*.xml"));
         sqlSessionFactoryBean

--- a/src/main/java/kr/bos/config/RedisConfig.java
+++ b/src/main/java/kr/bos/config/RedisConfig.java
@@ -1,7 +1,6 @@
 package kr.bos.config;
 
 import java.time.Duration;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -102,9 +101,7 @@ public class RedisConfig {
      * @since 1.0.0
      */
     @Bean
-    public RedisCacheManager redisCacheManager(
-        @Qualifier("redisCacheConnectionFactory") RedisConnectionFactory redisConnectionFactory) {
-
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisCacheConnectionFactory) {
         RedisCacheConfiguration redisCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
             .disableCachingNullValues().serializeKeysWith(SerializationPair.fromSerializer(
                 new StringRedisSerializer()))
@@ -113,7 +110,7 @@ public class RedisConfig {
             .entryTtl(Duration.ofDays(1L));
 
         return RedisCacheManager.RedisCacheManagerBuilder
-            .fromConnectionFactory(redisConnectionFactory)
+            .fromConnectionFactory(redisCacheConnectionFactory)
             .cacheDefaults(redisCacheConfig).build();
     }
 }

--- a/src/main/java/kr/bos/utils/DataSourceType.java
+++ b/src/main/java/kr/bos/utils/DataSourceType.java
@@ -1,0 +1,10 @@
+package kr.bos.utils;
+
+/**
+ * DataSourceType Master, Slave 구분을 위한 Enum Class.
+ *
+ * @since 1.0.0
+ */
+public enum DataSourceType {
+    MASTER, SLAVE
+}


### PR DESCRIPTION
MySQL Replication 적용을 위한 DataSourceConfig 작성.

MasterDataSource, SlaveDataSource를 구분하여 빈으로 등록.
트랜잭션의 readOnly=true라면 slave로 아니라면 master로 액세스.

스프링에서는 쿼리가 실행되기 전에 DataSource를 정하게 됨.
-> 쿼리가 발생하는 시점에 datasource의 커넥션을 가져오기 위해 lazyConnectionDataSourceProxy 적용.