### PR TITLE
예약 하기 기능 - 팬텀 리드 이슈 해결

### DIFF
--- a/src/main/java/kr/bos/mapper/RoomMapper.java
+++ b/src/main/java/kr/bos/mapper/RoomMapper.java
@@ -2,6 +2,7 @@ package kr.bos.mapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import kr.bos.model.domain.Room;
 import kr.bos.model.dto.response.RoomUseInfoRes;
 import org.apache.ibatis.annotations.Mapper;
@@ -28,4 +29,10 @@ public interface RoomMapper {
 
     boolean isExistsRoomNumber(@Param("roomNumber") Integer roomNumber,
         @Param("studyCafeId") Long studyCafeId);
+
+    Optional<Long> getRoomLockById(Long roomId);
+
+    void insertRoomLock(Long id);
+
+    void insertRoomLocks(List<Long> ids);
 }

--- a/src/main/java/kr/bos/model/domain/Room.java
+++ b/src/main/java/kr/bos/model/domain/Room.java
@@ -2,6 +2,7 @@ package kr.bos.model.domain;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.Getter;
 
 /**
  * Room Model.
@@ -9,6 +10,7 @@ import lombok.Builder;
  * @since 1.0.0
  */
 @Builder
+@Getter
 public class Room {
 
     private Long id;

--- a/src/main/java/kr/bos/service/ReservationService.java
+++ b/src/main/java/kr/bos/service/ReservationService.java
@@ -5,11 +5,11 @@ import java.time.temporal.ChronoUnit;
 import kr.bos.exception.DuplicatedException;
 import kr.bos.exception.NotFoundException;
 import kr.bos.mapper.ReservationMapper;
+import kr.bos.mapper.RoomMapper;
 import kr.bos.model.domain.Reservation;
 import kr.bos.model.dto.request.ReservationReq;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Reservation Service.
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationService {
 
     private final ReservationMapper reservationMapper;
+    private final RoomMapper roomMapper;
 
     /**
      * 예약하기.
@@ -40,6 +41,9 @@ public class ReservationService {
             || ChronoUnit.MINUTES.between(startTime, endTime) < 10) {
             throw new IllegalArgumentException("Please check your reservation time again.");
         }
+
+        roomMapper.getRoomLockById(roomId)
+            .orElseThrow(() -> new NotFoundException("Select not found room_lock"));
 
         if (reservationMapper.isExistsReservationByRoomIdAndUseTime(roomId, startTime, endTime)) {
             throw new DuplicatedException("This Reservation Time already exists.");

--- a/src/main/java/kr/bos/service/RoomService.java
+++ b/src/main/java/kr/bos/service/RoomService.java
@@ -52,6 +52,7 @@ public class RoomService {
             .build();
 
         roomMapper.insertRoom(room);
+        roomMapper.insertRoomLock(room.getId());
     }
 
     /**

--- a/src/main/java/kr/bos/service/StudyCafeService.java
+++ b/src/main/java/kr/bos/service/StudyCafeService.java
@@ -60,6 +60,13 @@ public class StudyCafeService {
         }
 
         roomMapper.insertRooms(rooms);
+
+        List<Long> roomIds = new ArrayList<>();
+        for (Room room : rooms) {
+            roomIds.add(room.getId());
+        }
+
+        roomMapper.insertRoomLocks(roomIds);
     }
 
     /**

--- a/src/main/resources/mapper/RoomMapper.xml
+++ b/src/main/resources/mapper/RoomMapper.xml
@@ -5,6 +5,11 @@
 
 <mapper namespace="kr.bos.mapper.RoomMapper">
 
+  <select id="getRoomLockById" resultType="long">
+    SELECT id
+    FROM room_locks WHERE room_id = #{roomId} FOR UPDATE
+  </select>
+
   <select id="isExistsRoomNumber" resultType="boolean">
     SELECT EXISTS
     (
@@ -15,7 +20,7 @@
     )
   </select>
 
-  <insert id="insertRooms">
+  <insert id="insertRooms" useGeneratedKeys="true" keyProperty="id">
     INSERT INTO rooms (study_cafe_id, number, capacity)
     VALUES
     <foreach collection="list" item="room" separator=",">
@@ -27,9 +32,22 @@
     </foreach>
   </insert>
 
-  <insert id="insertRoom">
+  <insert id="insertRoom" useGeneratedKeys="true" keyProperty="id">
     INSERT INTO rooms (study_cafe_id, number, capacity)
     VALUES (#{studyCafeId}, #{number}, #{capacity})
+  </insert>
+
+  <insert id="insertRoomLock">
+    INSERT INTO room_locks (room_id)
+    VALUES (#{id})
+  </insert>
+
+  <insert id="insertRoomLocks">
+    INSERT INTO room_locks (room_id)
+    VALUES
+    <foreach collection="list" item="id" separator=",">
+      ( #{id} )
+    </foreach>
   </insert>
 
   <update id="updateRoom">

--- a/src/test/java/kr/bos/service/ReservationServiceTest.java
+++ b/src/test/java/kr/bos/service/ReservationServiceTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import kr.bos.exception.DuplicatedException;
 import kr.bos.exception.NotFoundException;
 import kr.bos.mapper.ReservationMapper;
+import kr.bos.mapper.RoomMapper;
 import kr.bos.model.domain.Reservation;
 import kr.bos.model.dto.request.ReservationReq;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,9 @@ class ReservationServiceTest {
     @Mock
     ReservationMapper reservationMapper;
 
+    @Mock
+    RoomMapper roomMapper;
+
     ReservationReq reservationReq;
 
     @BeforeEach
@@ -42,6 +46,7 @@ class ReservationServiceTest {
     @Test
     @DisplayName("예약 생성에 성공합니다.")
     public void createReservationWhenSuccess() {
+        when(roomMapper.getRoomLockById(2L)).thenReturn(Optional.of(1L));
         when(reservationMapper.isExistsReservationByRoomIdAndUseTime(2L,
             reservationReq.getStartTime(), reservationReq.getEndTime())).thenReturn(false);
         reservationService.createReservation(reservationReq, 1L, 2L);
@@ -67,9 +72,18 @@ class ReservationServiceTest {
     @Test
     @DisplayName("예약 생성에 실패합니다. :이미 예약자가 존재합니다.")
     public void createReservationWhenFail2() {
+        when(roomMapper.getRoomLockById(2L)).thenReturn(Optional.of(1L));
         when(reservationMapper.isExistsReservationByRoomIdAndUseTime(2L,
             reservationReq.getStartTime(), reservationReq.getEndTime())).thenReturn(true);
         assertThrows(DuplicatedException.class,
+            () -> reservationService.createReservation(reservationReq, 1L, 2L));
+    }
+
+    @Test
+    @DisplayName("예약 생성에 실패합니다. :방 잠금 객체가 존재하지 않습니다.")
+    public void createReservationWhenFail3() {
+        when(roomMapper.getRoomLockById(2L)).thenReturn(Optional.empty());
+        assertThrows(NotFoundException.class,
             () -> reservationService.createReservation(reservationReq, 1L, 2L));
     }
 

--- a/src/test/java/kr/bos/service/RoomServiceTest.java
+++ b/src/test/java/kr/bos/service/RoomServiceTest.java
@@ -48,6 +48,7 @@ class RoomServiceTest {
         when(roomMapper.isExistsRoomNumber(1, 1L)).thenReturn(false);
         roomService.createRoom(roomReq, 1L);
         verify(roomMapper).insertRoom(any(Room.class));
+        verify(roomMapper).insertRoomLock(any());
     }
 
     @Test

--- a/src/test/java/kr/bos/service/StudyCafeServiceTest.java
+++ b/src/test/java/kr/bos/service/StudyCafeServiceTest.java
@@ -67,6 +67,7 @@ class StudyCafeServiceTest {
         studyCafeService.registerStudyCafe(1L, studyCafeReq);
         verify(studyCafeMapper).insertStudyCafe(any(StudyCafe.class));
         verify(roomMapper).insertRooms(any());
+        verify(roomMapper).insertRoomLocks(any());
     }
 
     @Test


### PR DESCRIPTION
- 직렬성 격리는 리스크가 너무 커 최후의 방법으로 사용하기로 함.
- 방을 생성할 때 잠금 테이블을 따로 생성하지않고 예약 레코드를 생성하는 방법도 있었지만
- room_locks 라는 잠금 테이블을 추가하는 방법으로 적용.

![스크린샷 2022-01-13 오후 12 47 04](https://user-images.githubusercontent.com/74256905/149262436-891d452c-1429-404b-9817-ed9c60350c73.png)

- 방을 생성할 때 room_locks의 레코드 생성
- 예약하기 요청시 가장 먼저 room_locks 레코드의 쓰기 잠금을 걸게됨.

---


예약 하기 기능을 구현하면서 발생했던 이슈사항을 글로 정리해봤습니다.
https://jinukix.tistory.com/137