### PR TITLE
스터디 카페 목록 기능 구현

### DIFF
--- a/src/main/java/kr/bos/controller/StudyCafeController.java
+++ b/src/main/java/kr/bos/controller/StudyCafeController.java
@@ -10,9 +10,9 @@ import kr.bos.model.dto.request.ReviewReq;
 import kr.bos.model.dto.request.RoomReq;
 import kr.bos.model.dto.request.SearchOption;
 import kr.bos.model.dto.request.SearchTimeReq;
-import kr.bos.model.dto.request.StudyCafeReq;
 import kr.bos.model.dto.response.PageInfo;
 import kr.bos.model.dto.response.StudyCafeDetailRes;
+import kr.bos.model.dto.response.StudyCafeRes;
 import kr.bos.service.ReservationService;
 import kr.bos.service.ReviewService;
 import kr.bos.service.RoomService;
@@ -46,18 +46,37 @@ public class StudyCafeController {
     private final ReservationService reservationService;
 
     /**
-     * 스터디 카페 등록하기.
+     * 스터디카페 목록 조회하기.
      *
-     * @param userId       유저 ID
-     * @param studyCafeReq 스터디카페 Request DTO
+     * @param userId        필터를 위한 userId (내 스터디 카페, 북마크 등록)
+     * @param keyword       검색어
+     * @param isBookmark    북마크 등록한 스터디 카페만 조회할 것인지
+     * @param isMyStudyCafe 내 스터디 카페만 조회할 것인지
+     * @param order         정렬 (최신순, 이름, 평점)
+     * @param page          페이지 번호
      * @since 1.0.0
      */
-    @PostMapping
+    @GetMapping
     @LoginCheck
-    @ResponseStatus(HttpStatus.CREATED)
-    public void registerStudyCafe(@CurrentUserId Long userId,
-        @Valid @RequestBody StudyCafeReq studyCafeReq) {
-        studyCafeService.registerStudyCafe(userId, studyCafeReq);
+    @ResponseStatus(HttpStatus.OK)
+    public PageInfo<StudyCafeRes> getStudyCafes(
+        @CurrentUserId Long userId,
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) Boolean isBookmark,
+        @RequestParam(required = false) Boolean isMyStudyCafe,
+        @RequestParam(required = false) String order,
+        @RequestParam(required = false) Integer page
+    ) {
+        SearchOption searchOption = SearchOption.builder()
+            .keyword(keyword)
+            .isMyStudyCafe(isMyStudyCafe)
+            .isBookmark(isBookmark)
+            .order(order)
+            .page(page)
+            .userId(userId)
+            .build();
+
+        return studyCafeService.getStudyCafes(searchOption);
     }
 
     /**

--- a/src/main/java/kr/bos/mapper/StudyCafeMapper.java
+++ b/src/main/java/kr/bos/mapper/StudyCafeMapper.java
@@ -3,7 +3,7 @@ package kr.bos.mapper;
 import java.util.List;
 import java.util.Optional;
 import kr.bos.model.domain.StudyCafe;
-import kr.bos.model.dto.request.StudyCafeReq;
+import kr.bos.model.dto.request.SearchOption;
 import kr.bos.model.dto.response.StudyCafeDetailRes;
 import kr.bos.model.dto.response.StudyCafeRes;
 import org.apache.ibatis.annotations.Mapper;
@@ -16,6 +16,10 @@ import org.apache.ibatis.annotations.Param;
  */
 @Mapper
 public interface StudyCafeMapper {
+
+    List<StudyCafeRes> selectStudyCafesBySearchOption(SearchOption searchOption);
+
+    Long selectStudyCafesCountsBySearchOption(SearchOption searchOption);
 
     void insertStudyCafe(StudyCafe studyCafe);
 

--- a/src/main/java/kr/bos/model/dto/request/OrderOption.java
+++ b/src/main/java/kr/bos/model/dto/request/OrderOption.java
@@ -1,0 +1,24 @@
+package kr.bos.model.dto.request;
+
+/**
+ * 검색에 사용할 정렬 옵션.
+ *
+ * @since 1.0.0
+ */
+public enum OrderOption {
+
+    /**
+     * 이름순으로 정렬되는 옵션.
+     */
+    NAME,
+
+    /**
+     * 최신순으로 정렬되는 옵션.
+     */
+    RECENTLY,
+
+    /**
+     * 리뷰 평균 순으로 정렬되는 옵션.
+     */
+    SCORE;
+}

--- a/src/main/java/kr/bos/model/dto/request/SearchOption.java
+++ b/src/main/java/kr/bos/model/dto/request/SearchOption.java
@@ -1,6 +1,6 @@
 package kr.bos.model.dto.request;
 
-import lombok.Builder;
+import java.util.Objects;
 import lombok.Getter;
 import org.apache.ibatis.session.RowBounds;
 
@@ -11,13 +11,45 @@ import org.apache.ibatis.session.RowBounds;
  *
  * @since 1.0.0
  */
-@Builder
 @Getter
 public class SearchOption {
 
-    private Integer offset;
-    private Integer limit;
+    private final String keyword;
+    private final Boolean isMyStudyCafe;
+    private final Boolean isBookmark;
+    private final OrderOption order;
+    private final Integer offset;
+    private final Integer limit;
+    private final Long userId;
 
+    private Integer cacheKey;
+
+    /**
+     * SearchOptionBuilder를 위한 생성자.
+     *
+     * @param keyword       검색어
+     * @param isMyStudyCafe 내 스터디 카페만 검색할 지
+     * @param isBookmark    북마크한 스터디 카페만 검색할 지
+     * @param order         정렬 옵션
+     * @param offset        OFFSET
+     * @param limit         LIMIT
+     * @param userId        유저 ID.
+     * @since 1.0.0
+     */
+    private SearchOption(String keyword, Boolean isMyStudyCafe, Boolean isBookmark,
+        OrderOption order, Integer offset, Integer limit, Long userId) {
+        this.keyword = keyword;
+        this.isMyStudyCafe = isMyStudyCafe;
+        this.isBookmark = isBookmark;
+        this.order = order;
+        this.offset = offset;
+        this.limit = limit;
+        this.userId = userId;
+
+        if (isMyStudyCafe || isBookmark) {
+            this.cacheKey = Objects.hash(keyword, order, offset, limit);
+        }
+    }
 
     public static SearchOptionBuilder builder() {
         return new SearchOptionBuilder();
@@ -32,8 +64,68 @@ public class SearchOption {
 
         private static final int DEFAULT_LIMIT = 10;
 
+        private String keyword;
+        private Boolean isMyStudyCafe = false;
+        private Boolean isBookmark = false;
+        private OrderOption order;
         private Integer offset;
         private Integer limit;
+        private Long userId;
+
+        /**
+         * 검색 키워드 지정.
+         *
+         * @since 1.0.0
+         */
+        public SearchOptionBuilder keyword(String keyword) {
+            this.keyword = keyword;
+            return this;
+        }
+
+        /**
+         * 내 스터디 카페만 조회.
+         *
+         * @since 1.0.0
+         */
+        public SearchOptionBuilder isMyStudyCafe(Boolean isMyStudyCafe) {
+            if (isMyStudyCafe == null) {
+                this.isMyStudyCafe = false;
+                return this;
+            }
+
+            this.isMyStudyCafe = isMyStudyCafe;
+            return this;
+        }
+
+        /**
+         * 북마크 등록한 스터디 카페만 조회.
+         *
+         * @since 1.0.0
+         */
+        public SearchOptionBuilder isBookmark(Boolean isBookmark) {
+            if (isBookmark == null) {
+                this.isBookmark = false;
+                return this;
+            }
+
+            this.isBookmark = isBookmark;
+            return this;
+        }
+
+        /**
+         * 검색 정렬 옵션 {@link OrderOption} 지정.
+         *
+         * @since 1.0.0
+         */
+        public SearchOptionBuilder order(String order) {
+            if (order == null) {
+                this.order = OrderOption.RECENTLY;
+                return this;
+            }
+
+            this.order = OrderOption.valueOf(order);
+            return this;
+        }
 
         /**
          * page 번호를 입력받아 {@link RowBounds} 를 생성. LIMIT의 기본 값은 10.
@@ -56,8 +148,19 @@ public class SearchOption {
             return this;
         }
 
+        /**
+         * isMyStudyCafe, isBookmark 필터 처리를 위한 userId.
+         *
+         * @since 1.0.0
+         */
+        public SearchOptionBuilder userId(Long userId) {
+            this.userId = userId;
+            return this;
+        }
+
         public SearchOption build() {
-            return new SearchOption(offset, limit);
+            return new SearchOption(keyword, isMyStudyCafe, isBookmark, order, offset, limit,
+                userId);
         }
     }
 }

--- a/src/main/java/kr/bos/model/dto/response/StudyCafeRes.java
+++ b/src/main/java/kr/bos/model/dto/response/StudyCafeRes.java
@@ -19,22 +19,7 @@ import lombok.NoArgsConstructor;
 public class StudyCafeRes {
 
     private Long id;
-
-    private Long userId;
-
     private String title;
-
     private String address;
-
-    private String thumbnail;
-
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
-
-    private Double reviewAverage;
-
-    private Integer bookMarked;
-
-    private Integer emptyRoomCount;
+    private Float reviewAverage;
 }

--- a/src/main/java/kr/bos/service/ReviewService.java
+++ b/src/main/java/kr/bos/service/ReviewService.java
@@ -9,6 +9,7 @@ import kr.bos.model.dto.request.SearchOption;
 import kr.bos.model.dto.response.PageInfo;
 import kr.bos.model.dto.response.ReviewRes;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +47,7 @@ public class ReviewService {
      * @param studyCafeId 스터디카페 ID
      * @since 1.0.0
      */
+    @CacheEvict(value = "studyCafes", allEntries = true)
     public void createReview(ReviewReq reviewReq, Long userId, Long studyCafeId) {
         Review review = Review.builder()
             .userId(userId)
@@ -65,6 +67,7 @@ public class ReviewService {
      * @param reviewId  리뷰 ID
      * @since 1.0.0
      */
+    @CacheEvict(value = "studyCafes", allEntries = true)
     public void updateReview(ReviewReq reviewReq, Long userId, Long reviewId) {
         Review review = Review.builder()
             .id(reviewId)
@@ -86,6 +89,7 @@ public class ReviewService {
      * @param reviewId 리뷰 ID
      * @since 1.0.0
      */
+    @CacheEvict(value = "studyCafes", allEntries = true)
     public void deleteReview(Long userId, Long reviewId) {
         int deleteCount = reviewMapper.deleteReview(userId, reviewId);
         if (deleteCount == 0) {

--- a/src/main/resources/mapper/StudyCafeMapper.xml
+++ b/src/main/resources/mapper/StudyCafeMapper.xml
@@ -15,6 +15,50 @@
     )
   </select>
 
+  <select id="selectStudyCafesBySearchOption" resultType="kr.bos.model.dto.response.StudyCafeRes">
+    SELECT study_cafes.id AS id, title, address, AVG(score) AS reviewAverage
+    FROM study_cafes
+    LEFT JOIN reviews ON study_cafes.id = reviews.study_cafe_id
+    <where>
+      <if test="keyword != null">
+        title LIKE CONCAT(#{keyword}, '%')
+      </if>
+      <if test="isBookmark == true">
+        AND study_cafes.id IN (SELECT study_cafe_id FROM bookmarks WHERE user_id = #{userId})
+      </if>
+      <if test="isMyStudyCafe == true">
+        AND study_cafes.user_id = #{userId}
+      </if>
+    </where>
+    GROUP BY reviews.study_cafe_id, study_cafes.id, title, address
+    <if test='order.name.equals("RECENTLY")'>
+      ORDER BY study_cafes.created_at
+    </if>
+    <if test='order.name.equals("NAME")'>
+      ORDER BY study_cafes.title
+    </if>
+    <if test='order.name.equals("SCORE")'>
+      ORDER BY reviewAverage
+    </if>
+    LIMIT #{offset}, #{limit}
+  </select>
+
+  <select id="selectStudyCafesCountsBySearchOption" resultType="long">
+    SELECT COUNT(*)
+    FROM study_cafes
+    <where>
+      <if test="keyword != null">
+        title LIKE CONCAT(#{keyword}, '%')
+      </if>
+      <if test="isBookmark == true">
+        AND study_cafes.id IN (SELECT study_cafe_id FROM bookmarks WHERE user_id = #{userId})
+      </if>
+      <if test="isMyStudyCafe == true">
+        AND study_cafes.user_id = #{userId}
+      </if>
+    </where>
+  </select>
+
   <select id="selectStudyCafeById" resultType="kr.bos.model.domain.StudyCafe">
     SELECT *
     FROM study_cafes

--- a/src/test/java/kr/bos/model/dto/request/SearchOptionTest.java
+++ b/src/test/java/kr/bos/model/dto/request/SearchOptionTest.java
@@ -1,6 +1,8 @@
 package kr.bos.model.dto.request;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
@@ -9,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class SearchOptionTest {
 
     @Test
-    @DisplayName("SearchOption 생성에 성공합니다. :페이지 번호 정상 입력.")
+    @DisplayName("SearchOption 생성에 성공합니다.")
     public void createSearchOptionTestWhenSucces1s() {
         SearchOption searchOption = SearchOption.builder().page(1).build();
         assertEquals(searchOption.getOffset(), 0);
@@ -19,12 +21,59 @@ class SearchOptionTest {
 
         searchOption = SearchOption.builder().page(10).build();
         assertEquals(searchOption.getOffset(), 90);
+
+        searchOption = SearchOption.builder()
+            .keyword("keyword")
+            .isBookmark(null)
+            .isMyStudyCafe(null)
+            .order(null)
+            .userId(1L)
+            .build();
+
+        assertEquals(searchOption.getKeyword(), "keyword");
+        assertEquals(searchOption.getIsMyStudyCafe(), false);
+        assertEquals(searchOption.getIsBookmark(), false);
+        assertEquals(searchOption.getOrder(), OrderOption.RECENTLY);
+        assertEquals(searchOption.getUserId(), 1L);
+        assertNull(searchOption.getCacheKey());
+
+        searchOption = SearchOption.builder()
+            .isMyStudyCafe(true)
+            .isBookmark(true)
+            .order("SCORE")
+            .build();
+
+        assertEquals(searchOption.getIsMyStudyCafe(), true);
+        assertEquals(searchOption.getIsBookmark(), true);
+        assertEquals(searchOption.getOrder(), OrderOption.SCORE);
+        assertNotNull(searchOption.getCacheKey());
+
+        searchOption = SearchOption.builder()
+            .order("NAME")
+            .isMyStudyCafe(null)
+            .isBookmark(true)
+            .build();
+
+        assertEquals(searchOption.getOrder(), OrderOption.NAME);
+        assertNotNull(searchOption.getCacheKey());
+
+        searchOption = SearchOption.builder()
+            .isMyStudyCafe(null)
+            .isBookmark(true)
+            .build();
+
+        assertNotNull(searchOption.getCacheKey());
     }
 
     @Test
     @DisplayName("SearchOption 생성에 성공합니다. :페이지 번호 입력하지 않는 경우.")
     public void createSearchOptionTestWhenSuccess2() {
-        SearchOption searchOption = SearchOption.builder().page(null).build();
+        SearchOption searchOption = SearchOption.builder()
+            .isBookmark(null)
+            .isMyStudyCafe(null)
+            .page(null)
+            .build();
+
         assertEquals(searchOption.getOffset(), 0);
     }
 

--- a/src/test/java/kr/bos/service/StudyCafeServiceTest.java
+++ b/src/test/java/kr/bos/service/StudyCafeServiceTest.java
@@ -1,5 +1,6 @@
 package kr.bos.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -16,9 +17,11 @@ import kr.bos.mapper.RoomMapper;
 import kr.bos.mapper.StudyCafeMapper;
 import kr.bos.model.domain.StudyCafe;
 import kr.bos.model.dto.request.RoomReq;
+import kr.bos.model.dto.request.SearchOption;
 import kr.bos.model.dto.request.SearchTimeReq;
 import kr.bos.model.dto.request.StudyCafeReq;
 import kr.bos.model.dto.response.StudyCafeDetailRes;
+import kr.bos.model.dto.response.StudyCafeRes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,6 +70,24 @@ class StudyCafeServiceTest {
         studyCafeService.registerStudyCafe(1L, studyCafeReq);
         verify(studyCafeMapper).insertStudyCafe(any(StudyCafe.class));
         verify(roomMapper).insertRooms(any());
+    }
+
+    @Test
+    @DisplayName("스터디 카페 목록 조회에 성공합니다.")
+    public void getStudyCafesTestWhenSuccess() {
+        SearchOption searchOption = SearchOption.builder().build();
+        List<StudyCafeRes> studyCafeResList = new ArrayList<>();
+
+        when(studyCafeMapper.selectStudyCafesBySearchOption(searchOption)).thenReturn(
+            studyCafeResList);
+        when(studyCafeMapper.selectStudyCafesCountsBySearchOption(searchOption)
+        ).thenReturn(100L);
+
+        var result = studyCafeService.getStudyCafes(searchOption);
+        assertEquals(result.getTotalCount(), 100L);
+        assertEquals(result.getList(), studyCafeResList);
+        verify(studyCafeMapper).selectStudyCafesBySearchOption(searchOption);
+        verify(studyCafeMapper).selectStudyCafesCountsBySearchOption(searchOption);
     }
 
     @Test


### PR DESCRIPTION
스터디 카페 목록 기능 구현.
해당 기능 구현은 제가 맡아서 진행하기로 했습니다.

RESPONSE
~~~json
{
    "totalCount": 32,
    "list": [
        {
            "id": 1,
            "title": "giraffe 스터디 카페",
            "address": "Suite 721 0735 구로면, 창원시, 울산 18186",
            "reviewAverage": 2.5
        },
        ...
    ]
}
~~~

기존에는 이용횟수, 현재 남은 방의 갯수 등의 정보도 같이 조회되었으나, 
예약하기, 예약취소 등의 기능들이 캐싱에 영향이 가고, 꼭 필요한 조회 항목은 아니기 때문에 제거.

- 문자열 검색: ('%문자%')의 경우 인덱스를 사용하기 힘들어 ('문자%') 검색으로 적용
- 정렬: 이름, 최신순, 리뷰 평균 점수순으로 정렬가능.
- 필터: 내 스터디 카페, 북마크 등록한 스터디 카페

단 필터의 경우 각 사용자마다 조회되는 리스트의 차이가 발생.(사용자마다 보유하고 있는 스터디 카페나, 북마크 목록이 다르기 때문)
-> 필터를 적용하면 캐싱을 적용하지 않습니다.

캐싱 적용.
- 리뷰 평균 점수도 조회하기 때문에 추가적으로 CacheEvict 설정: 리뷰 (생성, 수정, 삭제)